### PR TITLE
Fix background + add title and homepage for custom list

### DIFF
--- a/uBlock.txt
+++ b/uBlock.txt
@@ -1,3 +1,6 @@
+! Title: FandomFixed
+! Homepage: https://github.com/squabbled/FandomFixed
+
 ! fix the entire layout, remove sidebar, ads, spam, etc
 fandom.com##.global-navigation
 fandom.com##.anon.global-navigation
@@ -95,3 +98,5 @@ help.fandom.com###fandom_notice
 help.gamepedia.com###fandom_notice
 gamepedia.com###fandom_notice
 fandom.com###fandom_notice
+! Fix background
+fandom.com##.fandom-community-header__background:style(width: 100% !important;)

--- a/uBlock.txt
+++ b/uBlock.txt
@@ -41,6 +41,7 @@ fandom.com##.global-top-navigation__action-wrapper
 fandom.com##:root { --desktop-global-navigation-width: unset !important; }
 fandom.com###community-navigation > .sign-in.global-action__item
 fandom.com##.community-navigation { transform: translateY(100%) !important; }
+fandom.com###global-top-navigation
 
 ! search
 fandom.com##.top-results


### PR DESCRIPTION
Fixes a black line appearing on the right of some wikis (tested on https://murder-drones.fandom.com and https://geometry-dash.fandom.com)
![Capture d’écran (810)](https://github.com/user-attachments/assets/63ef6cc1-dbc7-4a9e-8869-1ef934e1c321)
![Capture d’écran (811)](https://github.com/user-attachments/assets/76d2b1f8-5ba3-4c93-a848-8359207fb291)

I also added a Title and a Homepage to the filter so it shows up nicely when importing the file as a custom URL filter
![Capture d’écran (809)](https://github.com/user-attachments/assets/07b78139-5b03-4b33-ae1f-3b09d89d6dd8)
