### PR TITLE
Adds compatibility for AdGuard Safari

### DIFF
--- a/uBlock.txt
+++ b/uBlock.txt
@@ -38,9 +38,9 @@ fandom.com##a.is-hidden-on-smaller-breakpoints.wds-is-secondary.wds-button:nth-o
 fandom.com##.wds-is-advertise.wds-global-footer__section
 fandom.com##.wds-is-fandom-overview.wds-global-footer__section
 fandom.com##.global-top-navigation__action-wrapper
-fandom.com##:root { --desktop-global-navigation-width: unset !important; }
+fandom.com##:root:style(--desktop-global-navigation-width: unset !important;)
 fandom.com###community-navigation > .sign-in.global-action__item
-fandom.com##.community-navigation { transform: translateY(100%) !important; }
+fandom.com##.community-navigation:style(transform: translateY(100%) !important;)
 fandom.com###global-top-navigation
 
 ! search


### PR DESCRIPTION
So if you try to use this list with AdGuard for Safari, AdGuard seems to not be able to understand the syntax with brackets
![Capture d’écran 2025-07-18 à 19 02 29](https://github.com/user-attachments/assets/693e8b36-19e1-4688-ae0a-e93bdd04f853)
However, when you replace these 2 lines with this syntax, it fixes it
![Capture d’écran 2025-07-18 à 19 02 54](https://github.com/user-attachments/assets/ddc27d2d-23a1-42cf-96bd-b4c7418883ea)
And it does not modify its behavior with uBlock Origin