### PR TITLE
Fix background again + bring back comments

### DIFF
--- a/uBlock.txt
+++ b/uBlock.txt
@@ -19,7 +19,6 @@ fandom.com##.WikiaRail.right-rail-wrapper
 fandom.com##.page__right-rail
 fandom.com##.fandom-community-header__top-container > .wds-button-group.wiki-tools > a.wds-is-secondary.wds-button:nth-of-type(2)
 fandom.com##.is-visible.fandom-sticky-header > .wds-button-group.wiki-tools > a.wds-is-secondary.wds-button:nth-of-type(2)
-fandom.com###mw-data-after-content
 fandom.com##.mcf-wrapper
 fandom.com##.global-footer__content > div:nth-of-type(4)
 fandom.com##.global-footer__section-social-links.global-footer__section
@@ -101,3 +100,4 @@ gamepedia.com###fandom_notice
 fandom.com###fandom_notice
 ! Fix background
 fandom.com##.fandom-community-header__background:style(width: 100% !important;)
+fandom.com##body > div:style(margin-left: 0px !important)


### PR DESCRIPTION
Adding `fandom.com##body > div:style(margin-left: 0px !important)` removes the black bar appearing of the left side
And removing `fandom.com###mw-data-after-content` brings back the comment section
I'm not sure of the reason why it was there, since it was the only thing being removed
If there was a good reason for it, I can change it back